### PR TITLE
Add support for async processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jollydays/camel-hystrix-endpoint.svg?branch=master)](https://travis-ci.org/jollydays/camel-hystrix-endpoint)
 
-Camel endpoint which wraps child endpoints into a synchronous hystrix circuit breaker.
+Camel endpoint which wraps child endpoints into a synchronous or asynchronous hystrix circuit breaker.
 
 This project allows easy integration of hystrix components into camel routes. A very simple example might look like this:
 

--- a/src/test/java/com/jollydays/camel/HystrixProducerTest.java
+++ b/src/test/java/com/jollydays/camel/HystrixProducerTest.java
@@ -111,7 +111,7 @@ public class HystrixProducerTest extends CamelTestSupport {
 
     @Test
     public void shouldRespectMaxExecutionTime() throws InterruptedException {
-        slowResultEndpoint.expectedBodiesReceived("test");
+        slowResultEndpoint.expectedBodiesReceived("test", "test");
         final Object tooSlow = slowRouteTemplate.requestBody("test");
         assertEquals("error", tooSlow);
         ConfigurationManager.getConfigInstance().setProperty(SLOW_COMMAND_TIMEOUT, 3000);


### PR DESCRIPTION
This PR changes `HystrixProducer` to be an `AsyncProducer`.

When the underlying child producer is also an `AsyncProducer`, a `HystrixObservableCommand` will be used for asynchronous execution instead of a synchronous `HystrixCommand`.